### PR TITLE
Remove project from the menu configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ menu:
   Home: /
   Archives: /archives
   About: /about.html
-  Project: /project.html
 
 
 default_post_icon: 🧙


### PR DESCRIPTION
According to [the README](https://github.com/tomap/hexo-theme-minidyne/blame/117f95190bc788992a225dcd05056c12e1998ad2/README.md#L95-L101) the default configuration for the menu does not contain "Project".
This PR removes the Project link.